### PR TITLE
Update README 2006 works for episodic2006 (hl2ep1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ There have been many updates to Source Engine since its release in 2004. Therefo
 | Version        | Half-Life 2                      | Half-Life 2: Episode 1           | Half-Life 2: Episode 2           | Portal                       |
 |----------------|----------------------------------|----------------------------------|----------------------------------|------------------------------|
 | 3420           | X                                | X                                | X                                | speedrun_demorecord-2007.dll |
-| 4044           | **speedrun_demorecord-2006.dll** | X                                | X                                | X                            |
+| 4044           | **speedrun_demorecord-2006.dll** | **speedrun_demorecord-2006.dll** | X                                | X                            |
 | 4104           | X                                | X                                | speedrun_demorecord-2007.dll     | X                            |
 | 5135           | speedrun_demorecord-2007.dll     | **speedrun_demorecord-2007.dll** | **speedrun_demorecord-2007.dll** | speedrun_demorecord-2007.dll |
 | SteamPipe      | speedrun_demorecord-2013.dll     | **speedrun_demorecord-2013.dll** | **speedrun_demorecord-2013.dll** | speedrun_demorecord-2013.dll |


### PR DESCRIPTION
Confirmed working on episodic2006 "mod" ran on Source SDK Base 2006 binaries, when put in .steam/steam/steamapps/common/Source SDK Base/bin instead of .steam/steam/steamapps/sourcemods/episodic2006/bin

```] version
Protocol version 7
Exe version 1.0.0.0 (episodicSDK2006)
Exe build: 17:27:58 Dec  3 2009 (4044)
```

```
] plugin_load speedrun_demorecord-2006.dll
Speedrun_demorecord Loaded
Loaded plugin "speedrun_demorecord-2006.dll"
] speedrun_save yourmum
] speedrun_start
Speedrun starting now...
Loading from save...
Dropped unnamed from server (Server shutting down)
Loading game from SAVE\yourmum.sav...
Spawn Server ep1_citadel_00
Begin loading faces (loads materials)
End loading faces (loads materials)
Loading game from //MOD/SAVE/ep1_citadel_00.HL1...
execing skill_manifest.cfg
execing skill.cfg
execing skill_episodic.cfg
Game started
No pure server whitelist. sv_pure = 0
CAsyncWavDataCache:  1 .wavs total 0 bytes, 0.00 % of capacity
Initializing renderer...
Section [Scenes]: 1608 resources total 25.73 KB, 1.23 % of limit (2.10 MB)
DataTable warning: env_sprite: Out-of-range value (200.000000) in SendPropFloat 'm_flGlowProxySize', clamping.
Recording to .\2021.02.02-02.00.08\ep1_citadel_00.dem...
VehicleType:class C_PropVehicleChoreoGeneric:
Saving game to SAVE\quick.sav...
Completed demo, recording time 2.4, game frames 148.
Dropped unnamed from server (Server shutting down)
Loading game from SAVE\quick.sav...
Spawn Server ep1_citadel_00
Begin loading faces (loads materials)
End loading faces (loads materials)
Loading game from //MOD/SAVE/ep1_citadel_00.HL1...
execing skill_manifest.cfg
execing skill.cfg
execing skill_episodic.cfg
Game started
No pure server whitelist. sv_pure = 0
CAsyncWavDataCache:  30 .wavs total 0 bytes, 0.00 % of capacity
Initializing renderer...
Section [Scenes]: 1608 resources total 104.59 KB, 4.99 % of limit (2.10 MB)
DataTable warning: env_sprite: Out-of-range value (200.000000) in SendPropFloat 'm_flGlowProxySize', clamping.
Recording to .\2021.02.02-02.00.08\ep1_citadel_00_1.dem...
VehicleType:class C_PropVehicleChoreoGeneric:
] stop
Completed demo, recording time 1.1, game frames 117.
] speedrun_stop
Speedrun will STOP now...```